### PR TITLE
Fix sync of incorrect prices with EE content staging

### DIFF
--- a/Command/Sync.php
+++ b/Command/Sync.php
@@ -152,7 +152,7 @@ class Sync extends Command
                 )
                 ->join(
                     ['t3' => $tableName],
-                    't1.product_id = t3.'.$decColName
+                    't2.'.$decColName.' = t3.'.$decColName
                 )
                 ->where('t1.product_id > ?', $this->lastSyncProd)
                 ->where('t3.attribute_id = ?', $attributeId)


### PR DESCRIPTION
## The problem

When using Adobe Commerce content staging, a product entity (having entity_id) can have multiple records (with row_id). Some core tables reference products by entity_id values, and some reference row_id.

The extension mostly handles this, but there's one case that's missed, where prices for the product sync are joined by `cataloginventory_stock_item.product_id`. This table always references an entity_id, but EAV tables (including price) reference row_id on Commerce. Because of this, when content staging is in use, it will sync prices for unrelated products.

## The fix

This PR changes the join condition for `catalog_product_entity_decimal`. Instead of (effectively)
```
cataloginventory_stock_item.product_id = catalog_product_entity_decimal.row_id
```
it changes to (effectively)
```
catalog_product_entity.row_id = catalog_product_entity_decimal.row_id
```
where catalog_product_entity is already joined as "t2" on line 150.

Since catalog_product_entity and catalog_product_entity_decimal link by row_id on Commerce, and entity_id on Magento Open Source, and `$decColName` contains the appropriate column name in both cases, this should handle both.